### PR TITLE
fix: フロントエンド連携に向けたユーザー認証API修正

### DIFF
--- a/src/main/java/com/example/todoapp/application/service/AuthenticationService.java
+++ b/src/main/java/com/example/todoapp/application/service/AuthenticationService.java
@@ -33,8 +33,7 @@ public class AuthenticationService {
         User user = new User();
         user.setEmail(request.getEmail());
         user.setPassword(passwordEncoder.encode(request.getPassword()));
-        user.setFirstName(request.getFirstName());
-        user.setLastName(request.getLastName());
+        user.setUsername(request.getUsername());
         user.setEnabled(true);
         user.setCreatedAt(LocalDateTime.now());
         user.setUpdatedAt(LocalDateTime.now());
@@ -47,14 +46,18 @@ public class AuthenticationService {
                 .authorities(new ArrayList<>())
                 .build();
 
-        String token = jwtService.generateToken(userDetails);
+        String accessToken = jwtService.generateToken(userDetails);
+        String refreshToken = jwtService.generateRefreshToken(userDetails);
 
-        return new AuthenticationResponse(
-                token,
+        AuthenticationResponse.UserResponse userResponse = new AuthenticationResponse.UserResponse(
+                savedUser.getId(),
+                savedUser.getUsername(),
                 savedUser.getEmail(),
-                savedUser.getFirstName(),
-                savedUser.getLastName()
+                savedUser.getCreatedAt().toString(),
+                savedUser.getUpdatedAt().toString()
         );
+
+        return new AuthenticationResponse(accessToken, refreshToken, userResponse);
     }
 
     public AuthenticationResponse login(LoginRequest request) {
@@ -74,13 +77,17 @@ public class AuthenticationService {
                 .authorities(new ArrayList<>())
                 .build();
 
-        String token = jwtService.generateToken(userDetails);
+        String accessToken = jwtService.generateToken(userDetails);
+        String refreshToken = jwtService.generateRefreshToken(userDetails);
 
-        return new AuthenticationResponse(
-                token,
+        AuthenticationResponse.UserResponse userResponse = new AuthenticationResponse.UserResponse(
+                user.getId(),
+                user.getUsername(),
                 user.getEmail(),
-                user.getFirstName(),
-                user.getLastName()
+                user.getCreatedAt().toString(),
+                user.getUpdatedAt().toString()
         );
+
+        return new AuthenticationResponse(accessToken, refreshToken, userResponse);
     }
 }

--- a/src/main/java/com/example/todoapp/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/todoapp/common/config/SecurityConfig.java
@@ -40,8 +40,8 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(authz -> authz
-                .requestMatchers("/api/auth/**").permitAll()
-                .requestMatchers("/api/todos/**").authenticated()
+                .requestMatchers("/api/v1/auth/**").permitAll()
+                .requestMatchers("/api/v1/todos/**").authenticated()
                 .requestMatchers("/actuator/health").permitAll()
                 .anyRequest().authenticated()
             )

--- a/src/main/java/com/example/todoapp/domain/model/User.java
+++ b/src/main/java/com/example/todoapp/domain/model/User.java
@@ -14,8 +14,7 @@ public class User {
     private Long id;
     private String email;
     private String password;
-    private String firstName;
-    private String lastName;
+    private String username;
     private boolean enabled;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/java/com/example/todoapp/infrastructure/persistence/entity/UserEntity.java
+++ b/src/main/java/com/example/todoapp/infrastructure/persistence/entity/UserEntity.java
@@ -24,11 +24,8 @@ public class UserEntity {
     @Column(nullable = false)
     private String password;
 
-    @Column(nullable = false)
-    private String firstName;
-
-    @Column(nullable = false)
-    private String lastName;
+    @Column(unique = true, nullable = false)
+    private String username;
 
     @Column(nullable = false)
     private boolean enabled = true;

--- a/src/main/java/com/example/todoapp/infrastructure/persistence/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/example/todoapp/infrastructure/persistence/repository/UserRepositoryImpl.java
@@ -41,8 +41,7 @@ public class UserRepositoryImpl implements UserRepository {
                 entity.getId(),
                 entity.getEmail(),
                 entity.getPassword(),
-                entity.getFirstName(),
-                entity.getLastName(),
+                entity.getUsername(),
                 entity.isEnabled(),
                 entity.getCreatedAt(),
                 entity.getUpdatedAt()
@@ -54,8 +53,7 @@ public class UserRepositoryImpl implements UserRepository {
         entity.setId(user.getId());
         entity.setEmail(user.getEmail());
         entity.setPassword(user.getPassword());
-        entity.setFirstName(user.getFirstName());
-        entity.setLastName(user.getLastName());
+        entity.setUsername(user.getUsername());
         entity.setEnabled(user.isEnabled());
         entity.setCreatedAt(user.getCreatedAt());
         entity.setUpdatedAt(user.getUpdatedAt());

--- a/src/main/java/com/example/todoapp/infrastructure/security/JwtService.java
+++ b/src/main/java/com/example/todoapp/infrastructure/security/JwtService.java
@@ -44,6 +44,10 @@ public class JwtService {
         return buildToken(extraClaims, userDetails, tokenExpiration);
     }
 
+    public String generateRefreshToken(UserDetails userDetails) {
+        return buildToken(new HashMap<>(), userDetails, Duration.ofDays(7));
+    }
+
     private String buildToken(Map<String, Object> extraClaims, UserDetails userDetails, Duration expiration) {
         Instant now = Instant.now();
         return Jwts.builder()

--- a/src/main/java/com/example/todoapp/presentation/controller/AuthenticationController.java
+++ b/src/main/java/com/example/todoapp/presentation/controller/AuthenticationController.java
@@ -1,6 +1,8 @@
 package com.example.todoapp.presentation.controller;
 
 import com.example.todoapp.application.service.AuthenticationService;
+import com.example.todoapp.application.service.UserContextService;
+import com.example.todoapp.domain.model.User;
 import com.example.todoapp.presentation.dto.request.LoginRequest;
 import com.example.todoapp.presentation.dto.request.RegisterRequest;
 import com.example.todoapp.presentation.dto.response.AuthenticationResponse;
@@ -11,11 +13,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 public class AuthenticationController {
 
     private final AuthenticationService authenticationService;
+    private final UserContextService userContextService;
 
     @PostMapping("/register")
     public ResponseEntity<AuthenticationResponse> register(
@@ -31,5 +34,20 @@ public class AuthenticationController {
     ) {
         AuthenticationResponse response = authenticationService.login(request);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<AuthenticationResponse.UserResponse> getCurrentUser() {
+        User currentUser = userContextService.getCurrentUser();
+        
+        AuthenticationResponse.UserResponse userResponse = new AuthenticationResponse.UserResponse(
+                currentUser.getId(),
+                currentUser.getUsername(),
+                currentUser.getEmail(),
+                currentUser.getCreatedAt().toString(),
+                currentUser.getUpdatedAt().toString()
+        );
+        
+        return ResponseEntity.ok(userResponse);
     }
 }

--- a/src/main/java/com/example/todoapp/presentation/dto/request/RegisterRequest.java
+++ b/src/main/java/com/example/todoapp/presentation/dto/request/RegisterRequest.java
@@ -20,11 +20,7 @@ public class RegisterRequest {
     @Size(min = 6, message = "Password must be at least 6 characters")
     private String password;
 
-    @NotBlank(message = "First name is required")
-    @Size(max = 50, message = "First name must not exceed 50 characters")
-    private String firstName;
-
-    @NotBlank(message = "Last name is required")
-    @Size(max = 50, message = "Last name must not exceed 50 characters")
-    private String lastName;
+    @NotBlank(message = "Username is required")
+    @Size(min = 3, max = 20, message = "Username must be between 3 and 20 characters")
+    private String username;
 }

--- a/src/main/java/com/example/todoapp/presentation/dto/response/AuthenticationResponse.java
+++ b/src/main/java/com/example/todoapp/presentation/dto/response/AuthenticationResponse.java
@@ -10,15 +10,17 @@ import lombok.NoArgsConstructor;
 public class AuthenticationResponse {
     
     private String accessToken;
-    private String tokenType = "Bearer";
-    private String email;
-    private String firstName;
-    private String lastName;
+    private String refreshToken;
+    private UserResponse user;
 
-    public AuthenticationResponse(String accessToken, String email, String firstName, String lastName) {
-        this.accessToken = accessToken;
-        this.email = email;
-        this.firstName = firstName;
-        this.lastName = lastName;
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserResponse {
+        private Long id;
+        private String username;
+        private String email;
+        private String createdAt;
+        private String updatedAt;
     }
 }

--- a/src/main/resources/db/migration/V4__update_user_table_to_username.sql
+++ b/src/main/resources/db/migration/V4__update_user_table_to_username.sql
@@ -1,0 +1,5 @@
+-- Update user table to use username instead of firstName and lastName
+ALTER TABLE users DROP COLUMN first_name;
+ALTER TABLE users DROP COLUMN last_name;
+ALTER TABLE users ADD COLUMN username VARCHAR(20) NOT NULL;
+ALTER TABLE users ADD CONSTRAINT uk_users_username UNIQUE (username);


### PR DESCRIPTION
## Summary
- フロントエンドE2Eテスト連携のためのAPI統一とユーザーモデル変更
- /api/v1/authエンドポイント統一、/meエンドポイント追加でフロントエンド期待値に対応
- ユーザーテーブルスキーマをfirstName/lastNameからusernameに変更

## Test plan
- [ ] 既存の全テストがパス
- [ ] フロントエンドE2Eテストとの連携確認
- [ ] 新しいユーザー認証フローの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)